### PR TITLE
Add possibility to override ContentProductGuiConfig::MAX_NUMBER_PRODUCTS_IN_PRODUCT_ABSTRACT_LIST

### DIFF
--- a/src/Spryker/Zed/ContentProductGui/Communication/ContentProductGuiCommunicationFactory.php
+++ b/src/Spryker/Zed/ContentProductGui/Communication/ContentProductGuiCommunicationFactory.php
@@ -48,6 +48,7 @@ class ContentProductGuiCommunicationFactory extends AbstractCommunicationFactory
     public function createProductAbstractSelectedTable(array $idProductAbstracts, ?string $identifierSuffix = null): ProductAbstractSelectedTable
     {
         return new ProductAbstractSelectedTable(
+            $this->getConfig(),
             $this->getProductQueryContainer(),
             $this->getProductImageFacade(),
             $this->getLocaleFacade()->getCurrentLocale(),

--- a/src/Spryker/Zed/ContentProductGui/Communication/Table/ProductAbstractSelectedTable.php
+++ b/src/Spryker/Zed/ContentProductGui/Communication/Table/ProductAbstractSelectedTable.php
@@ -7,10 +7,13 @@
 
 namespace Spryker\Zed\ContentProductGui\Communication\Table;
 
+use Generated\Shared\Transfer\LocaleTransfer;
 use Orm\Zed\Product\Persistence\SpyProductAbstract;
+use Orm\Zed\Product\Persistence\SpyProductAbstractQuery;
 use Spryker\Service\UtilText\Model\Url\Url;
 use Spryker\Zed\ContentProductGui\Communication\Controller\ProductAbstractController;
 use Spryker\Zed\ContentProductGui\ContentProductGuiConfig;
+use Spryker\Zed\ContentProductGui\Dependency\Facade\ContentProductGuiToProductImageInterface;
 use Spryker\Zed\Gui\Communication\Table\TableConfiguration;
 
 class ProductAbstractSelectedTable extends AbstractProductAbstractTable
@@ -49,6 +52,33 @@ class ProductAbstractSelectedTable extends AbstractProductAbstractTable
      * @var string
      */
     public const BUTTON_MOVE_DOWN = 'Move Down';
+
+    /**
+     * @param \Spryker\Zed\ContentProductGui\ContentProductGuiConfig $config
+     * @param \Orm\Zed\Product\Persistence\SpyProductAbstractQuery $productQueryContainer
+     * @param \Spryker\Zed\ContentProductGui\Dependency\Facade\ContentProductGuiToProductImageInterface $productImageFacade
+     * @param \Generated\Shared\Transfer\LocaleTransfer $localeTransfer
+     * @param string|null $identifierSuffix
+     * @param array $idProductAbstracts
+     */
+    public function __construct(
+        ContentProductGuiConfig $config,
+        SpyProductAbstractQuery $productQueryContainer,
+        ContentProductGuiToProductImageInterface $productImageFacade,
+        LocaleTransfer $localeTransfer,
+        ?string $identifierSuffix,
+        array $idProductAbstracts = []
+    ) {
+        $this->config = $config;
+
+        parent::__construct(
+            $productQueryContainer,
+            $productImageFacade,
+            $localeTransfer,
+            $identifierSuffix,
+            $idProductAbstracts
+        );
+    }
 
     /**
      * @param \Spryker\Zed\Gui\Communication\Table\TableConfiguration $config
@@ -129,7 +159,7 @@ class ProductAbstractSelectedTable extends AbstractProductAbstractTable
             ->filterByFkLocale($this->localeTransfer->getIdLocale())
             ->endUse();
 
-        $this->setLimit(ContentProductGuiConfig::MAX_NUMBER_PRODUCTS_IN_PRODUCT_ABSTRACT_LIST);
+        $this->setLimit($this->config->getMaxProductsInProductAbstractList());
         $queryResults = $this->runQuery($query, $config, true);
 
         /** @var \Orm\Zed\Product\Persistence\SpyProductAbstract $productAbstractEntity */

--- a/src/Spryker/Zed/ContentProductGui/ContentProductGuiConfig.php
+++ b/src/Spryker/Zed/ContentProductGui/ContentProductGuiConfig.php
@@ -26,6 +26,16 @@ class ContentProductGuiConfig extends AbstractBundleConfig
     /**
      * @api
      *
+     * @return int
+     */
+    public function getMaxProductsInProductAbstractList(): int
+    {
+        return static::MAX_NUMBER_PRODUCTS_IN_PRODUCT_ABSTRACT_LIST;
+    }
+
+    /**
+     * @api
+     *
      * @return array<string, string>
      */
     public function getContentWidgetTemplates(): array


### PR DESCRIPTION
## PR Description

* The constant `MAX_NUMBER_PRODUCTS_IN_PRODUCT_ABSTRACT_LIST` is directly used:
  * https://github.com/spryker/content-product-gui/blob/master/src/Spryker/Zed/ContentProductGui/Communication/Table/ProductAbstractSelectedTable.php#L132

* This makes it hard to adapt the constant and it's necessary to override `ProductAbstractSelectedTable::prepareData()` method.
* Introducing a getter in `ContentProductGuiConfig` which returns `static::MAX_NUMBER_PRODUCTS_IN_PRODUCT_ABSTRACT_LIST` should solve the issue.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
