### PR TITLE
Fixed getRowData function

### DIFF
--- a/assets/Zed/js/modules/add-product-table.js
+++ b/assets/Zed/js/modules/add-product-table.js
@@ -179,7 +179,7 @@ var ProductListContentItem = function (
     this.getRowData = function (productTable, productId) {
         var tableData = productTable.dataTable().api().data().toArray();
         var rowData = tableData.find(function (item) {
-            if (item[0] === Number(productId)) {
+            if (Number(item[0]) === Number(productId)) {
                 return item;
             }
         });


### PR DESCRIPTION
## PR Description

item[0] in getRowData function returns string data type leading to failing IF. Converted in int type.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
